### PR TITLE
chore(copilot): enable sync for esyfo-microfrontends

### DIFF
--- a/copilot-config/copilot-sync-config.yml
+++ b/copilot-config/copilot-sync-config.yml
@@ -79,8 +79,6 @@ overrides:
     skip: true
   esyfovarsel_analyse:
     skip: true
-  esyfo-microfrontends:
-    skip: true
   syfooppfolgingsplanservice:
     skip: true
   team-esyfo:


### PR DESCRIPTION
Fjerner `esyfo-microfrontends` fra skip-listen i copilot-sync-config.yml, slik at `ecli copilot sync` inkluderer dette repoet.

Ved neste sync vil repoet få:
- Felles managed instruksjoner (auth, security, observability, nais)
- Frontend-profil instruksjoner (frontend.instructions.md, testing-typescript.instructions.md)
- Team-agenter, prompts og skills

Lokalt eide copilot-instruksjoner (copilot-instructions.md, astro.instructions.md, migration.instructions.md) er allerede opprettet direkte i esyfo-microfrontends.